### PR TITLE
Move slack webhook url to secret manager.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 type Config struct {
-	ProjectID string
-	DripEnv   string
+	ProjectID                   string
+	DripEnv                     string
+	SlackRegistryChannelWebhook string
 }

--- a/main.go
+++ b/main.go
@@ -21,8 +21,9 @@ func main() {
 	connection_string := os.Getenv("DB_CONNECTION_STRING")
 
 	config := config.Config{
-		ProjectID: os.Getenv("PROJECT_ID"),
-		DripEnv:   os.Getenv("DRIP_ENV"),
+		ProjectID:                   os.Getenv("PROJECT_ID"),
+		DripEnv:                     os.Getenv("DRIP_ENV"),
+		SlackRegistryChannelWebhook: os.Getenv("SLACK_REGISTRY_CHANNEL_WEBHOOK"),
 	}
 
 	var dsn string

--- a/run-service-prod.yaml
+++ b/run-service-prod.yaml
@@ -22,6 +22,11 @@ spec:
               secretKeyRef:
                 key: 1
                 name: PROD_SUPABASE_CONNECTION_STRING
+        - name: SLACK_REGISTRY_CHANNEL_WEBHOOK
+          valueFrom:
+              secretKeyRef:
+                key: 1
+                name: PROD_SLACK_REGISTRY_CHANNEL_WEBHOOK
         - name: PROJECT_ID
           value: dreamboothy
         # TODO(robinhuang): Switch to a list of strings

--- a/server/server.go
+++ b/server/server.go
@@ -82,7 +82,7 @@ func (s *Server) Start() error {
 		return err
 	}
 
-	slackService := gateway.NewSlackService()
+	slackService := gateway.NewSlackService(s.Config)
 
 	mon, err := monitoring.NewMetricClient(context.Background())
 	if err != nil {


### PR DESCRIPTION
Webhook URL keeps getting deleted because it's exposed in a public repository.