### PR TITLE
initial waterfall backend

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -206,6 +206,61 @@ paths:
           description: Commit not found
         '500':
           description: Internal server error
+  /gitcommitsummary:
+    get:
+      summary: Retrieve a summary of git commits
+      description: Returns a summary of git commits, including status, start time, and end time.
+      parameters:
+        - in: query
+          name: repoName
+          required: false
+          schema:
+            type: string
+            default: comfyanonymous/ComfyUI
+          description: The repository name to filter the git commits by.
+        - in: query
+          name: branchName
+          required: false
+          schema:
+            type: string
+          description: The branch name to filter the git commits by.
+        - in: query
+          name: page
+          required: false
+          schema:
+            type: integer
+            default: 1
+          description: The page number to retrieve.
+        - in: query
+          name: pageSize
+          required: false
+          schema:
+            type: integer
+            default: 10
+          description: The number of items to include per page.
+      responses:
+        '200':
+          description: Successfully retrieved git commit summaries
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  commitSummaries:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/GitCommitSummary'
+                  totalNumberOfPages:
+                    type: integer
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
   /workflowresult/{workflowResultId}:
     get:
       summary: Retrieve a specific commit by ID
@@ -1735,6 +1790,30 @@ components:
           type: string
           format: date-time
           description: The timestamp when the commit was made
+    GitCommitSummary:
+      type: object
+      properties:
+        commit_hash:
+          type: string
+          description: The hash of the commit
+        commit_name:
+          type: string
+          description: The name of the commit
+        branch_name:
+          type: string
+          description: The branch where the commit was made
+        author:
+          type: string
+          description: The author of the commit
+        timestamp:
+          type: string
+          format: date-time
+          description: The timestamp when the commit was made
+        status_summary:
+          type: object
+          description: A map of operating system to status pairs
+          additionalProperties:
+            type: string
     User:
       type: object
       properties:

--- a/server/implementation/cicd.go
+++ b/server/implementation/cicd.go
@@ -146,6 +146,7 @@ func (impl *DripStrictServerImplementation) GetGitcommitsummary(ctx context.Cont
 		log.Ctx(ctx).Info().Msgf("Filtering git commit by branch name %s", *request.Params.BranchName)
 		query.Where(ciworkflowresult.HasGitcommitWith(gitcommit.BranchNameEQ(*request.Params.BranchName)))
 	}
+	query.Order(ciworkflowresult.ByGitcommitField(gitcommit.FieldCommitTimestamp, sql.OrderDesc()))
 
 	// Execute the query to get all commits
 	commits, err := query.All(ctx)

--- a/server/implementation/cicd.go
+++ b/server/implementation/cicd.go
@@ -2,10 +2,13 @@ package implementation
 
 import (
 	"context"
+	"fmt"
 	"registry-backend/drip"
 	"registry-backend/ent/ciworkflowresult"
 	"registry-backend/ent/gitcommit"
+	"registry-backend/ent/schema"
 	"registry-backend/mapper"
+	"sort"
 	"strings"
 
 	"entgo.io/ent/dialect/sql"
@@ -117,6 +120,103 @@ func (impl *DripStrictServerImplementation) GetGitcommit(ctx context.Context, re
 	return drip.GetGitcommit200JSONResponse{
 		JobResults:         &results,
 		TotalNumberOfPages: &numberOfPages,
+	}, nil
+}
+
+func (impl *DripStrictServerImplementation) GetGitcommitsummary(ctx context.Context, request drip.GetGitcommitsummaryRequestObject) (drip.GetGitcommitsummaryResponseObject, error) {
+	log.Ctx(ctx).Info().Msg("Getting git commit summary")
+
+	// TODO: This is implementing as a dense processing at time of request, but this should really be preprocessed in advance
+	// probably even stored in the database
+	query := impl.Client.CIWorkflowResult.Query().
+		WithGitcommit().
+		WithStorageFile()
+
+	// Apply filters
+	repoName := "comfyanonymous/ComfyUI"
+	if request.Params.RepoName != nil {
+		repoName = *request.Params.RepoName
+	}
+	repoName = strings.ToLower(repoName)
+	if request.Params.RepoName != nil {
+		log.Ctx(ctx).Info().Msgf("Filtering git commit by repo name %s", repoName)
+		query.Where(ciworkflowresult.HasGitcommitWith(gitcommit.RepoNameEQ(repoName)))
+	}
+	if request.Params.BranchName != nil {
+		log.Ctx(ctx).Info().Msgf("Filtering git commit by branch name %s", *request.Params.BranchName)
+		query.Where(ciworkflowresult.HasGitcommitWith(gitcommit.BranchNameEQ(*request.Params.BranchName)))
+	}
+
+	// Execute the query to get all commits
+	commits, err := query.All(ctx)
+	if err != nil {
+		log.Ctx(ctx).Error().Msgf("Error retrieving git commits w/ err: %v", err)
+		message := fmt.Sprintf("Error retrieving git commits: %v", err)
+		return drip.GetGitcommitsummary500JSONResponse{
+			Message: &message,
+		}, nil
+	}
+	log.Ctx(ctx).Info().Msgf("Retrieved %d commits to summarize", len(commits))
+
+	// Create summaries
+	summaries := make(map[string]*drip.GitCommitSummary)
+	for _, commit := range commits {
+		summary, exists := summaries[commit.Edges.Gitcommit.CommitHash]
+		if !exists {
+			summary = &drip.GitCommitSummary{
+				CommitHash:    &commit.Edges.Gitcommit.CommitHash,
+				Timestamp:     &commit.Edges.Gitcommit.Timestamp,
+				Author:        &commit.Edges.Gitcommit.Author,
+				CommitName:    &commit.Edges.Gitcommit.CommitMessage,
+				BranchName:    &commit.Edges.Gitcommit.BranchName,
+				StatusSummary: &map[string]string{},
+			}
+			summaries[commit.Edges.Gitcommit.CommitHash] = summary
+		}
+		_, exists = (*summary.StatusSummary)[commit.OperatingSystem]
+		if !exists {
+			(*summary.StatusSummary)[commit.OperatingSystem] = string(commit.Status)
+		} else if commit.Status == schema.WorkflowRunStatusTypeFailed {
+			(*summary.StatusSummary)[commit.OperatingSystem] = string(commit.Status)
+		}
+	}
+
+	// Convert map to slice for pagination
+	summarySlice := make([]drip.GitCommitSummary, 0, len(summaries))
+	for _, summary := range summaries {
+		summarySlice = append(summarySlice, *summary)
+	}
+
+	// Sort summaries by commit date (newest first)
+	sort.Slice(summarySlice, func(i, j int) bool {
+		dateI := summarySlice[i].Timestamp
+		dateJ := summarySlice[j].Timestamp
+		return dateI.After(*dateJ)
+	})
+
+	// Pagination
+	page := 1
+	pageSize := 10
+	if request.Params.Page != nil {
+		page = *request.Params.Page
+	}
+	if request.Params.PageSize != nil {
+		pageSize = *request.Params.PageSize
+	}
+
+	start := (page - 1) * pageSize
+	end := start + pageSize
+	if end > len(summarySlice) {
+		end = len(summarySlice)
+	}
+
+	paginatedSummaries := summarySlice[start:end]
+	totalPages := (len(summarySlice) + pageSize - 1) / pageSize
+
+	log.Ctx(ctx).Info().Msgf("Git commit summaries retrieved successfully, %d summaries, %d of %d pages", len(paginatedSummaries), page, totalPages)
+	return drip.GetGitcommitsummary200JSONResponse{
+		CommitSummaries:    &paginatedSummaries,
+		TotalNumberOfPages: &totalPages,
 	}, nil
 }
 

--- a/server/implementation/cicd.go
+++ b/server/implementation/cicd.go
@@ -166,7 +166,7 @@ func (impl *DripStrictServerImplementation) GetGitcommitsummary(ctx context.Cont
 		if !exists {
 			summary = &drip.GitCommitSummary{
 				CommitHash:    &commit.Edges.Gitcommit.CommitHash,
-				Timestamp:     &commit.Edges.Gitcommit.Timestamp,
+				Timestamp:     &commit.Edges.Gitcommit.CommitTimestamp,
 				Author:        &commit.Edges.Gitcommit.Author,
 				CommitName:    &commit.Edges.Gitcommit.CommitMessage,
 				BranchName:    &commit.Edges.Gitcommit.BranchName,

--- a/server/middleware/authentication/firebase_auth.go
+++ b/server/middleware/authentication/firebase_auth.go
@@ -27,6 +27,7 @@ func FirebaseAuthMiddleware(entClient *ent.Client) echo.MiddlewareFunc {
 		regexp.MustCompile(`^/health$`):                                {"GET"},
 		regexp.MustCompile(`^/upload-artifact$`):                       {"POST"},
 		regexp.MustCompile(`^/gitcommit$`):                             {"POST", "GET"},
+		regexp.MustCompile(`^/gitcommitsummary$`):                      {"GET"},
 		regexp.MustCompile(`^/workflowresult/[^/]+$`):                  {"GET"},
 		regexp.MustCompile(`^/branch$`):                                {"GET"},
 		regexp.MustCompile(`^/publishers/[^/]+/nodes/[^/]+/versions$`): {"POST"},

--- a/server/middleware/authentication/firebase_auth_test.go
+++ b/server/middleware/authentication/firebase_auth_test.go
@@ -35,6 +35,7 @@ func TestAllowlist(t *testing.T) {
 		{"Artifact POST", "/upload-artifact", "POST", true},
 		{"Git Commit POST", "/gitcommit", "POST", true},
 		{"Git Commit GET", "/gitcommit", "GET", true},
+		{"Git Commit Summary GET", "/gitcommitsummary", "GET", true},
 		{"Branch GET", "/branch", "GET", true},
 		{"Node Version Path POST", "/publishers/pub123/nodes/node456/versions", "POST", true},
 		{"Publisher POST", "/publishers", "POST", false},


### PR DESCRIPTION
adds route `/gitcommitsummary` to be the backend of the ci-dashboard waterfall

This isn't particularly optimal. at all. but it's a start! towards moving the impl off the frontend and into the backend. Ideally it should precompute this summary data and store in database. For initial impl it just computes on the fly.

Limitation I'm hitting is `GetGitcommit` seems to supply timestamps properly, but `GetGitcommitsummary` is giving me `0001-01-01T00:00:00Z` which ain't right. I'm not sure why, main difference here is `GetGitcommit` has a special custom translation layer that does all sorts of special wonk, whereas for `GetGitcommitsummary` I just let it pass the data through directly, which as far as I can tell should just work? Regardless, `commit.Edges.Gitcommit.Timestamp` itself appears to be wrong from some debugging, so I'm not sure why that's happening