### PR TITLE
Don't include node version's status reason in ListAllNodes

### DIFF
--- a/integration-tests/registry_integration_test.go
+++ b/integration-tests/registry_integration_test.go
@@ -736,11 +736,13 @@ func TestRegistryNodeVersion(t *testing.T) {
 				Downloads:     &expDl,
 				Rating:        &expRate,
 				Status:        &nodeStatus,
+				StatusDetail:  proto.String(""),
 				Category:      proto.String(""),
 			}
 			expectedNode.LatestVersion.DownloadUrl = node.LatestVersion.DownloadUrl // generated
 			expectedNode.LatestVersion.Deprecated = node.LatestVersion.Deprecated   // generated
 			expectedNode.LatestVersion.CreatedAt = node.LatestVersion.CreatedAt     // generated
+			expectedNode.LatestVersion.StatusReason = nil                           // Filtered out
 			expectedNode.Publisher.CreatedAt = node.Publisher.CreatedAt
 			assert.Equal(t, expectedNode, node)
 		}

--- a/integration-tests/registry_integration_test.go
+++ b/integration-tests/registry_integration_test.go
@@ -736,7 +736,6 @@ func TestRegistryNodeVersion(t *testing.T) {
 				Downloads:     &expDl,
 				Rating:        &expRate,
 				Status:        &nodeStatus,
-				StatusDetail:  proto.String(""),
 				Category:      proto.String(""),
 			}
 			expectedNode.LatestVersion.DownloadUrl = node.LatestVersion.DownloadUrl // generated

--- a/server/implementation/registry.go
+++ b/server/implementation/registry.go
@@ -289,6 +289,7 @@ func (s *DripStrictServerImplementation) ListAllNodes(
 		// attach information of latest version if available
 		if len(dbNode.Edges.Versions) > 0 {
 			apiNode.LatestVersion = mapper.DbNodeVersionToApiNodeVersion(dbNode.Edges.Versions[0])
+			apiNode.LatestVersion.StatusReason = nil
 		}
 
 		// Map publisher information


### PR DESCRIPTION
This field can be huge and increases the payload and response time by a lot.

Status reason can be retrieved at the GetNodeVersion level.