### PR TITLE
Fix Request Logger

### DIFF
--- a/server/middleware/request_logger_test.go
+++ b/server/middleware/request_logger_test.go
@@ -1,0 +1,86 @@
+package middleware
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type tArrayWriter struct {
+	logs [][]byte
+}
+
+func (w *tArrayWriter) Write(p []byte) (n int, err error) {
+	w.logs = append(w.logs, p)
+	return len(p), nil
+}
+
+func TestRequestLogger(t *testing.T) {
+	jsonBody, err := json.Marshal(map[string]interface{}{
+		"status": "status",
+		"name":   "name",
+	})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/publishers", bytes.NewReader(jsonBody))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	res := httptest.NewRecorder()
+	e := echo.New()
+
+	e.Use(RequestLoggerMiddleware())
+
+	t.Run("BodyHasBeenRead", func(t *testing.T) {
+		writer := &tArrayWriter{}
+		logger := zerolog.New(writer).With().Timestamp().Logger()
+		ctx := logger.WithContext(context.Background())
+		req := req.WithContext(ctx)
+
+		var readBody []byte
+		e.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
+			return func(c echo.Context) (err error) {
+				readBody, err = io.ReadAll(c.Request().Body)
+				if err != nil {
+					return err
+				}
+				return fmt.Errorf("terminate")
+			}
+		})
+		e.ServeHTTP(res, req)
+
+		assert.Equal(t, jsonBody, readBody, "the body should still be readable after RequestLoggerMiddleware")
+		require.Len(t, writer.logs, 1)
+		logged := map[string]interface{}{}
+		require.NoError(t, json.Unmarshal(writer.logs[0], &logged))
+		require.Contains(t, logged, "RequestBody")
+		assert.Contains(t, logged["RequestBody"].(string), string(jsonBody), "should contain the request body")
+	})
+
+	t.Run("BodyHasNotBeenRead", func(t *testing.T) {
+		writer := &tArrayWriter{}
+		logger := zerolog.New(writer).With().Timestamp().Logger()
+		ctx := logger.WithContext(context.Background())
+		req := req.WithContext(ctx)
+
+		e.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
+			return func(c echo.Context) (err error) {
+				return fmt.Errorf("terminate")
+			}
+		})
+		e.ServeHTTP(res, req)
+
+		require.Len(t, writer.logs, 1)
+		logged := map[string]interface{}{}
+		require.NoError(t, json.Unmarshal(writer.logs[0], &logged))
+		require.Contains(t, logged, "RequestBody")
+		assert.NotContains(t, logged["RequestBody"].(string), string(jsonBody), "should contain the request body")
+	})
+}


### PR DESCRIPTION
It took some time to discover that the middleware attempted to read the body after the drip server implementation had already finished processing it, leaving no body content for the middleware to read.

This fix resolves the issue and enhances performance by allowing the middleware to read the body concurrently with the drip server implementation, eliminating the need to process the body twice.