### PR TITLE
Disable MetricsMiddleware

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1,8 +1,14 @@
 package server
 
 import (
+	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
 	"context"
 	"fmt"
+	"github.com/labstack/echo/v4"
+	labstack_middleware "github.com/labstack/echo/v4/middleware"
+	"github.com/newrelic/go-agent/v3/integrations/nrecho-v4"
+	"github.com/newrelic/go-agent/v3/newrelic"
+	"github.com/rs/zerolog/log"
 	"registry-backend/config"
 	generated "registry-backend/drip"
 	"registry-backend/ent"
@@ -16,14 +22,6 @@ import (
 	"registry-backend/server/middleware"
 	"registry-backend/server/middleware/authentication"
 	drip_authorization "registry-backend/server/middleware/authorization"
-	"registry-backend/server/middleware/metric"
-
-	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
-	"github.com/labstack/echo/v4"
-	labstack_middleware "github.com/labstack/echo/v4/middleware"
-	"github.com/newrelic/go-agent/v3/integrations/nrecho-v4"
-	"github.com/newrelic/go-agent/v3/newrelic"
-	"github.com/rs/zerolog/log"
 )
 
 type ServerDependencies struct {
@@ -125,7 +123,7 @@ func (s *Server) Start() error {
 	}))
 	e.Use(middleware.RequestLoggerMiddleware())
 	e.Use(middleware.ResponseLoggerMiddleware())
-	e.Use(metric.MetricsMiddleware(&s.Dependencies.MonitoringClient, s.Config))
+	//e.Use(metric.MetricsMiddleware(&s.Dependencies.MonitoringClient, s.Config))
 	e.Use(authentication.FirebaseAuthMiddleware(s.Client))
 	e.Use(authentication.ServiceAccountAuthMiddleware())
 	e.Use(authentication.JWTAdminAuthMiddleware(s.Client, s.Config.JWTSecret))


### PR DESCRIPTION
A couple of tracing indicates that MetricsMiddleware could potentially causing spike in latency: 
* https://one.newrelic.com/nr1-core/apm-features/transactions/NjM2NTcxMXxBUE18QVBQTElDQVRJT058NTM2MDk3ODM3?account=6365711&duration=1800000&state=c9454926-1d48-36f4-23f6-feec0a2f5955
* https://one.newrelic.com/nr1-core/apm-features/transactions/NjM2NTcxMXxBUE18QVBQTElDQVRJT058NTM2MDk3ODM3?account=6365711&duration=1800000&state=aa45074a-2f0f-38d3-9ff8-fbb5b5e86ebc

Just want to test this thing since we are already collecting all the relevant metrics via newrelic. No more custom metrics we need to export via GCP. 