### PR TITLE
fix: add 5-minute timeout to security scan HTTP client

### DIFF
--- a/services/registry/registry_svc.go
+++ b/services/registry/registry_svc.go
@@ -1471,7 +1471,7 @@ func sendScanRequest(apiURL, fileURL string) (string, error) {
 
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{}
+	client := &http.Client{Timeout: 5 * time.Minute}
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("failed to send request: %w", err)


### PR DESCRIPTION
The `sendScanRequest` function in `services/registry/registry_svc.go` creates an `http.Client{}` with no timeout configured. This means the HTTP client uses Go's default behavior of no timeout, which can cause the caller to hang for 300s+ when scanning large node packs if the security scanner endpoint is slow or unresponsive.

This change adds a 5-minute timeout (`http.Client{Timeout: 5 * time.Minute}`) to bound the maximum duration of a single scan request, preventing indefinite hangs.