### PR TITLE
fix: guard against malformed UUIDs on unauthenticated endpoints

### DIFF
--- a/integration-tests/ci_cd_integration_test.go
+++ b/integration-tests/ci_cd_integration_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"registry-backend/config"
 	"registry-backend/drip"
 	"registry-backend/ent/gitcommit"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
 	"github.com/newrelic/go-agent/v3/newrelic"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -180,5 +182,28 @@ func TestCICD(t *testing.T) {
 		require.NoError(t, err, "should return error")
 		assert.IsType(t, drip.GetBranch200JSONResponse{}, res)
 		assert.Len(t, *res.(drip.GetBranch200JSONResponse).Branches, 0, "should return empty branch")
+	})
+
+	// UUID-hardening: malformed CommitId must return 400 before any Client query (parse guard returns early).
+	t.Run("GetGitcommit rejects malformed CommitId with 400", func(t *testing.T) {
+		_, err := impl.GetGitcommit(ctx, drip.GetGitcommitRequestObject{
+			Params: drip.GetGitcommitParams{CommitId: proto.String("not-a-uuid")},
+		})
+		require.Error(t, err)
+		he, ok := err.(*echo.HTTPError)
+		require.True(t, ok, "expected *echo.HTTPError, got %T", err)
+		assert.Equal(t, http.StatusBadRequest, he.Code)
+	})
+
+	// UUID-hardening: malformed WorkflowResultId must return 400 before any Client query (parse guard returns early).
+	// Route ^/workflowresult/[^/]+$ GET is unauthenticated (firebase_auth.go allowlist).
+	t.Run("GetWorkflowResult rejects malformed WorkflowResultId with 400", func(t *testing.T) {
+		_, err := impl.GetWorkflowResult(ctx, drip.GetWorkflowResultRequestObject{
+			WorkflowResultId: "not-a-uuid",
+		})
+		require.Error(t, err)
+		he, ok := err.(*echo.HTTPError)
+		require.True(t, ok, "expected *echo.HTTPError, got %T", err)
+		assert.Equal(t, http.StatusBadRequest, he.Code)
 	})
 }

--- a/mapper/common.go
+++ b/mapper/common.go
@@ -1,9 +1,30 @@
 package mapper
 
-// BoolPtrToBool function to convert a bool pointer to a bool, returns false if the pointer is nil
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// BoolPtrToBool converts a bool pointer to bool; returns false if the pointer is nil.
 func BoolPtrToBool(ptr *bool) bool {
 	if ptr == nil {
 		return false
 	}
 	return *ptr
+}
+
+// ParseUUIDParam parses a UUID from an optional query or path parameter string.
+// A nil pointer is treated as uuid.Nil with no error, preserving the existing
+// nil-guard semantics at call sites. A non-nil but malformed value returns an
+// error instead of panicking (replacing uuid.MustParse on user input).
+func ParseUUIDParam(s *string) (uuid.UUID, error) {
+	if s == nil {
+		return uuid.Nil, nil
+	}
+	id, err := uuid.Parse(*s)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("invalid UUID parameter %q: %w", *s, err)
+	}
+	return id, nil
 }

--- a/mapper/common_test.go
+++ b/mapper/common_test.go
@@ -1,0 +1,67 @@
+package mapper
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseUUIDParam(t *testing.T) {
+	validUUID := "550e8400-e29b-41d4-a716-446655440000"
+	parsedUUID := uuid.MustParse(validUUID)
+
+	tests := []struct {
+		name    string
+		input   *string
+		wantID  uuid.UUID
+		wantErr bool
+	}{
+		{
+			name:    "nil pointer returns uuid.Nil without error",
+			input:   nil,
+			wantID:  uuid.Nil,
+			wantErr: false,
+		},
+		{
+			name:    "valid UUID string is parsed correctly",
+			input:   &validUUID,
+			wantID:  parsedUUID,
+			wantErr: false,
+		},
+		{
+			name:    "garbage string returns error",
+			input:   strPtr("not-a-uuid"),
+			wantID:  uuid.Nil,
+			wantErr: true,
+		},
+		{
+			name:    "empty string returns error",
+			input:   strPtr(""),
+			wantID:  uuid.Nil,
+			wantErr: true,
+		},
+		{
+			name:    "truncated UUID returns error",
+			input:   strPtr("550e8400-e29b-41d4-a716"),
+			wantID:  uuid.Nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseUUIDParam(tt.input)
+			if tt.wantErr {
+				require.Error(t, err, "expected an error but got none")
+				assert.Equal(t, uuid.Nil, got)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantID, got)
+			}
+		})
+	}
+}
+
+func strPtr(s string) *string { return &s }

--- a/server/implementation/cicd.go
+++ b/server/implementation/cicd.go
@@ -3,6 +3,7 @@ package implementation
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"registry-backend/drip"
 	"registry-backend/ent/ciworkflowresult"
 	"registry-backend/ent/gitcommit"
@@ -14,16 +15,21 @@ import (
 
 	"entgo.io/ent/dialect/sql"
 	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
 	"github.com/rs/zerolog/log"
 )
 
 func (impl *DripStrictServerImplementation) GetGitcommit(ctx context.Context, request drip.GetGitcommitRequestObject) (drip.GetGitcommitResponseObject, error) {
 	defer tracing.TraceDefaultSegment(ctx, "DripStrictServerImplementation.GetGitcommit")()
 
-	var commitId uuid.UUID = uuid.Nil
+	commitId, err := mapper.ParseUUIDParam(request.Params.CommitId)
+	if err != nil {
+		log.Ctx(ctx).Warn().Msgf("invalid commitId parameter: %v", err)
+		// No 400 response type is generated for this operation; use echo's handler error.
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "commitId must be a valid UUID")
+	}
 	if request.Params.CommitId != nil {
 		log.Ctx(ctx).Info().Msgf("getting commit data for %s", *request.Params.CommitId)
-		commitId = uuid.MustParse(*request.Params.CommitId)
 	}
 
 	if request.Params.OperatingSystem != nil {
@@ -261,7 +267,14 @@ func (impl *DripStrictServerImplementation) GetWorkflowResult(ctx context.Contex
 	defer tracing.TraceDefaultSegment(ctx, "DripStrictServerImplementation.GetWorkflowResult")()
 
 	log.Ctx(ctx).Info().Msgf("Getting workflow result with ID %s", request.WorkflowResultId)
-	workflowId := uuid.MustParse(request.WorkflowResultId)
+	// WorkflowResultId is a plain string path param; use uuid.Parse directly (not ParseUUIDParam, which is for *string).
+	// This route is unauthenticated (allowlist: ^/workflowresult/[^/]+$ GET), so we must guard before any DB access.
+	workflowId, err := uuid.Parse(request.WorkflowResultId)
+	if err != nil {
+		log.Ctx(ctx).Warn().Msgf("invalid workflowResultId parameter: %v", err)
+		// No 400 response type is generated for this operation; use echo's handler error.
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "workflowResultId must be a valid UUID")
+	}
 	workflow, err := impl.Client.CIWorkflowResult.Query().WithGitcommit().WithStorageFile().Where(ciworkflowresult.IDEQ(workflowId)).First(ctx)
 
 	if err != nil {

--- a/services/registry/registry_svc.go
+++ b/services/registry/registry_svc.go
@@ -665,8 +665,12 @@ func (s *RegistryService) GetNodeVersion(ctx context.Context, client *ent.Client
 	defer tracing.TraceDefaultSegment(ctx, "RegistryService.GetNodeVersion")()
 
 	log.Ctx(ctx).Info().Msgf("getting node version %v", nodeVersionId)
+	id, err := uuid.Parse(nodeVersionId)
+	if err != nil {
+		return nil, fmt.Errorf("invalid node version ID %q: %w", nodeVersionId, err)
+	}
 	return client.NodeVersion.
-		Get(ctx, uuid.MustParse(nodeVersionId))
+		Get(ctx, id)
 }
 
 func (s *RegistryService) UpdateNodeVersion(ctx context.Context, client *ent.Client, update *ent.NodeVersionUpdateOne) (*ent.NodeVersion, error) {


### PR DESCRIPTION
A few handlers call `uuid.MustParse` directly on user input. `MustParse` panics on anything that isn't a valid UUID, and two of these endpoints are in the Firebase auth allowlist — so they're reachable without a token:

- `GET /gitcommit?commitId=<garbage>`
- `GET /workflowresult/<garbage>`

There's no `middleware.Recover()` in the stack, so this isn't a process crash — net/http recovers per-connection — but the caller gets a dropped connection instead of a real response, and every malformed request dumps a stack trace into the logs.

Swapped the `MustParse` calls for `uuid.Parse` and return a 400 instead. Added a small `ParseUUIDParam` helper for the optional `*string` params (keeps the existing `nil → uuid.Nil` behavior). Same change in `RegistryService.GetNodeVersion`, which is reached through the authenticated `DeleteNodeVersion` path.

Using `echo.NewHTTPError(400, ...)` since none of these ops have a generated 400 in the spec — the strict wrapper passes it through to echo's default error handler, which renders it as a 400.

Tests: unit tests for the helper plus two checks in `TestCICD` that a malformed id returns 400.

Left out, happy to follow up:
- `DeletePersonalAccessToken` has the same pattern but on an authenticated route.
- A global `middleware.Recover()` would be a cheap safety net for anything like this we miss.
