### PR TITLE
fix: return 400 instead of panicking on malformed user-supplied UUIDs

### DIFF
--- a/integration-tests/ci_cd_integration_test.go
+++ b/integration-tests/ci_cd_integration_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"registry-backend/config"
 	"registry-backend/drip"
 	"registry-backend/ent/gitcommit"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
 	"github.com/newrelic/go-agent/v3/newrelic"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -180,5 +182,28 @@ func TestCICD(t *testing.T) {
 		require.NoError(t, err, "should return error")
 		assert.IsType(t, drip.GetBranch200JSONResponse{}, res)
 		assert.Len(t, *res.(drip.GetBranch200JSONResponse).Branches, 0, "should return empty branch")
+	})
+
+	// UUID-hardening: malformed CommitId must return 400 before any Client query (parse guard returns early).
+	t.Run("GetGitcommit rejects malformed CommitId with 400", func(t *testing.T) {
+		_, err := impl.GetGitcommit(ctx, drip.GetGitcommitRequestObject{
+			Params: drip.GetGitcommitParams{CommitId: proto.String("not-a-uuid")},
+		})
+		require.Error(t, err)
+		he, ok := err.(*echo.HTTPError)
+		require.True(t, ok, "expected *echo.HTTPError, got %T", err)
+		assert.Equal(t, http.StatusBadRequest, he.Code)
+	})
+
+	// UUID-hardening: malformed WorkflowResultId must return 400 before any Client query (parse guard returns early).
+	// Route ^/workflowresult/[^/]+$ GET is unauthenticated (firebase_auth.go allowlist).
+	t.Run("GetWorkflowResult rejects malformed WorkflowResultId with 400", func(t *testing.T) {
+		_, err := impl.GetWorkflowResult(ctx, drip.GetWorkflowResultRequestObject{
+			WorkflowResultId: "not-a-uuid",
+		})
+		require.Error(t, err)
+		he, ok := err.(*echo.HTTPError)
+		require.True(t, ok, "expected *echo.HTTPError, got %T", err)
+		assert.Equal(t, http.StatusBadRequest, he.Code)
 	})
 }

--- a/mapper/common.go
+++ b/mapper/common.go
@@ -1,9 +1,30 @@
 package mapper
 
-// BoolPtrToBool function to convert a bool pointer to a bool, returns false if the pointer is nil
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// BoolPtrToBool converts a bool pointer to bool; returns false if the pointer is nil.
 func BoolPtrToBool(ptr *bool) bool {
 	if ptr == nil {
 		return false
 	}
 	return *ptr
+}
+
+// ParseUUIDParam parses a UUID from an optional query or path parameter string.
+// A nil pointer is treated as uuid.Nil with no error, preserving the existing
+// nil-guard semantics at call sites. A non-nil but malformed value returns an
+// error instead of panicking (replacing uuid.MustParse on user input).
+func ParseUUIDParam(s *string) (uuid.UUID, error) {
+	if s == nil {
+		return uuid.Nil, nil
+	}
+	id, err := uuid.Parse(*s)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("invalid UUID parameter %q: %w", *s, err)
+	}
+	return id, nil
 }

--- a/mapper/common_test.go
+++ b/mapper/common_test.go
@@ -1,0 +1,67 @@
+package mapper
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseUUIDParam(t *testing.T) {
+	validUUID := "550e8400-e29b-41d4-a716-446655440000"
+	parsedUUID := uuid.MustParse(validUUID)
+
+	tests := []struct {
+		name    string
+		input   *string
+		wantID  uuid.UUID
+		wantErr bool
+	}{
+		{
+			name:    "nil pointer returns uuid.Nil without error",
+			input:   nil,
+			wantID:  uuid.Nil,
+			wantErr: false,
+		},
+		{
+			name:    "valid UUID string is parsed correctly",
+			input:   &validUUID,
+			wantID:  parsedUUID,
+			wantErr: false,
+		},
+		{
+			name:    "garbage string returns error",
+			input:   strPtr("not-a-uuid"),
+			wantID:  uuid.Nil,
+			wantErr: true,
+		},
+		{
+			name:    "empty string returns error",
+			input:   strPtr(""),
+			wantID:  uuid.Nil,
+			wantErr: true,
+		},
+		{
+			name:    "truncated UUID returns error",
+			input:   strPtr("550e8400-e29b-41d4-a716"),
+			wantID:  uuid.Nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseUUIDParam(tt.input)
+			if tt.wantErr {
+				require.Error(t, err, "expected an error but got none")
+				assert.Equal(t, uuid.Nil, got)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantID, got)
+			}
+		})
+	}
+}
+
+func strPtr(s string) *string { return &s }

--- a/mapper/node_version.go
+++ b/mapper/node_version.go
@@ -10,8 +10,8 @@ import (
 	"github.com/google/uuid"
 )
 
-func ApiUpdateNodeVersionToUpdateFields(versionId string, updateRequest *drip.NodeVersionUpdateRequest, client *ent.Client) *ent.NodeVersionUpdateOne {
-	update := client.NodeVersion.UpdateOneID(uuid.MustParse(versionId))
+func ApiUpdateNodeVersionToUpdateFields(versionId uuid.UUID, updateRequest *drip.NodeVersionUpdateRequest, client *ent.Client) *ent.NodeVersionUpdateOne {
+	update := client.NodeVersion.UpdateOneID(versionId)
 	if updateRequest.Changelog != nil {
 		update.SetChangelog(*updateRequest.Changelog)
 	}

--- a/server/implementation/cicd.go
+++ b/server/implementation/cicd.go
@@ -3,6 +3,7 @@ package implementation
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"registry-backend/drip"
 	"registry-backend/ent/ciworkflowresult"
 	"registry-backend/ent/gitcommit"
@@ -14,16 +15,20 @@ import (
 
 	"entgo.io/ent/dialect/sql"
 	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
 	"github.com/rs/zerolog/log"
 )
 
 func (impl *DripStrictServerImplementation) GetGitcommit(ctx context.Context, request drip.GetGitcommitRequestObject) (drip.GetGitcommitResponseObject, error) {
 	defer tracing.TraceDefaultSegment(ctx, "DripStrictServerImplementation.GetGitcommit")()
 
-	var commitId uuid.UUID = uuid.Nil
+	commitId, err := mapper.ParseUUIDParam(request.Params.CommitId)
+	if err != nil {
+		log.Ctx(ctx).Warn().Msgf("invalid commitId parameter: %v", err)
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "commitId must be a valid UUID")
+	}
 	if request.Params.CommitId != nil {
 		log.Ctx(ctx).Info().Msgf("getting commit data for %s", *request.Params.CommitId)
-		commitId = uuid.MustParse(*request.Params.CommitId)
 	}
 
 	if request.Params.OperatingSystem != nil {
@@ -261,7 +266,11 @@ func (impl *DripStrictServerImplementation) GetWorkflowResult(ctx context.Contex
 	defer tracing.TraceDefaultSegment(ctx, "DripStrictServerImplementation.GetWorkflowResult")()
 
 	log.Ctx(ctx).Info().Msgf("Getting workflow result with ID %s", request.WorkflowResultId)
-	workflowId := uuid.MustParse(request.WorkflowResultId)
+	workflowId, err := mapper.ParseUUIDParam(&request.WorkflowResultId)
+	if err != nil {
+		log.Ctx(ctx).Warn().Msgf("invalid WorkflowResultId parameter: %v", err)
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "workflowResultId must be a valid UUID")
+	}
 	workflow, err := impl.Client.CIWorkflowResult.Query().WithGitcommit().WithStorageFile().Where(ciworkflowresult.IDEQ(workflowId)).First(ctx)
 
 	if err != nil {

--- a/server/implementation/registry.go
+++ b/server/implementation/registry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"registry-backend/drip"
 	"registry-backend/ent"
 	"registry-backend/ent/publisher"
@@ -15,7 +16,7 @@ import (
 	"registry-backend/tracing"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
 	"github.com/mixpanel/mixpanel-go"
 	"github.com/rs/zerolog/log"
 	"google.golang.org/protobuf/proto"
@@ -538,7 +539,12 @@ func (s *DripStrictServerImplementation) UpdateNodeVersion(
 	defer tracing.TraceDefaultSegment(ctx, "DripStrictServerImplementation.UpdateNodeVersion")()
 
 	// Update node version
-	updateOne := mapper.ApiUpdateNodeVersionToUpdateFields(request.VersionId, request.Body, s.Client)
+	versionId, err := mapper.ParseUUIDParam(&request.VersionId)
+	if err != nil {
+		log.Ctx(ctx).Warn().Msgf("invalid VersionId parameter: %v", err)
+		return drip.UpdateNodeVersion400JSONResponse{Message: "versionId must be a valid UUID"}, nil
+	}
+	updateOne := mapper.ApiUpdateNodeVersionToUpdateFields(versionId, request.Body, s.Client)
 	version, err := s.RegistryService.UpdateNodeVersion(ctx, s.Client, updateOne)
 	if ent.IsNotFound(err) {
 		log.Ctx(ctx).Error().Msgf("Node %s or it's version not found w/ err: %v", request.NodeId, err)
@@ -685,8 +691,14 @@ func (s *DripStrictServerImplementation) DeletePersonalAccessToken(
 		return drip.DeletePersonalAccessToken404JSONResponse{Message: "Invalid user ID"}, err
 	}
 
+	tokenId, err := mapper.ParseUUIDParam(&request.TokenId)
+	if err != nil {
+		log.Ctx(ctx).Warn().Msgf("invalid TokenId parameter: %v", err)
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "tokenId must be a valid UUID")
+	}
+
 	// Assert access token belongs to publisher
-	err = s.RegistryService.AssertAccessTokenBelongsToPublisher(ctx, s.Client, request.PublisherId, uuid.MustParse(request.TokenId))
+	err = s.RegistryService.AssertAccessTokenBelongsToPublisher(ctx, s.Client, request.PublisherId, tokenId)
 	switch {
 	case ent.IsNotFound(err):
 		log.Ctx(ctx).Warn().Msgf("Publisher with ID %s not found", request.PublisherId)
@@ -703,7 +715,7 @@ func (s *DripStrictServerImplementation) DeletePersonalAccessToken(
 	}
 
 	// Delete personal access token
-	err = s.RegistryService.DeletePersonalAccessToken(ctx, s.Client, uuid.MustParse(request.TokenId))
+	err = s.RegistryService.DeletePersonalAccessToken(ctx, s.Client, tokenId)
 	if err != nil {
 		errMessage := "Failed to delete personal access token: " + err.Error()
 		log.Ctx(ctx).Error().Msgf("Token deletion failed w/ err: %v", err)

--- a/services/registry/registry_svc.go
+++ b/services/registry/registry_svc.go
@@ -665,8 +665,12 @@ func (s *RegistryService) GetNodeVersion(ctx context.Context, client *ent.Client
 	defer tracing.TraceDefaultSegment(ctx, "RegistryService.GetNodeVersion")()
 
 	log.Ctx(ctx).Info().Msgf("getting node version %v", nodeVersionId)
+	id, err := uuid.Parse(nodeVersionId)
+	if err != nil {
+		return nil, fmt.Errorf("invalid node version ID %q: %w", nodeVersionId, err)
+	}
 	return client.NodeVersion.
-		Get(ctx, uuid.MustParse(nodeVersionId))
+		Get(ctx, id)
 }
 
 func (s *RegistryService) UpdateNodeVersion(ctx context.Context, client *ent.Client, update *ent.NodeVersionUpdateOne) (*ent.NodeVersion, error) {


### PR DESCRIPTION
## Problem

`uuid.MustParse` panics on a malformed UUID. Several handlers call it directly on
user-controlled UUIDs (path/query parameters and request bodies). There is no
`middleware.Recover()` in the echo stack, so a malformed value becomes an unhandled
panic — a per-request DoS plus a full stack-trace flooding the logs.

`GET /workflowresult/{workflowResultId}` is reachable **unauthenticated**, so that
endpoint is an anonymous panic vector — any client can crash the request handler with
a non-UUID id:

```
curl https://<host>/workflowresult/not-a-uuid
# panic: invalid UUID length: 10   (500 + goroutine dump in the logs)
```

## Fix

Add `mapper.ParseUUIDParam(*string) (uuid.UUID, error)`:

- a `nil` pointer maps to `uuid.Nil` with no error, preserving the existing nil-guard
  semantics at the call sites;
- a malformed value returns an error instead of panicking.

Route every user-input UUID parse through it and return `400` on a parse error:

- `GET /gitcommit` — `commitId`
- `GET /workflowresult` — `workflowResultId` (unauthenticated)
- `PATCH` node version — `versionId`
- `DELETE` personal access token — `tokenId`

`ApiUpdateNodeVersionToUpdateFields` now takes an already-parsed `uuid.UUID`.

The one remaining `uuid.MustParse` (in `DeleteNodeVersion`) parses a UUID that was
fetched from the database and round-tripped through `.String()` — it is not user input
and cannot be malformed, so it is intentionally left unchanged.

## Tests

Adds a table test for `ParseUUIDParam` (nil pointer → `uuid.Nil`; empty and malformed →
error; valid → parsed). `go build ./...`, `go vet ./...`, and `go test ./mapper/` pass.
